### PR TITLE
README: `pip` won't allow installing `pytorch-lightning==1.8.0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,16 +23,22 @@ ViSNet (shorted for “**V**ector-**S**calar **i**nteractive graph neural **Net*
 
 - Install the dependencies
 
-```shell
-conda create -y -n visnet python=3.9
-conda activate visnet
-conda install pytorch==1.11.0 torchvision==0.12.0 torchaudio==0.11.0 cudatoolkit=11.3 -c pytorch
-conda install pyg==2.1.0 -c pyg
-pip install pytorch-lightning==1.8.0
-pip install ase ase[test] ogb
-```
+   ```shell
+   conda create -y -n visnet python=3.9
+   conda activate visnet
+   conda install pytorch==1.11.0 torchvision==0.12.0 torchaudio==0.11.0 cudatoolkit=11.3 -c pytorch
+   conda install pyg==2.1.0 -c pyg
+   pip install pytorch-lightning==1.8.0  # see the note below
+   pip install ase ase[test] ogb
+   ```
 
-Note: newer versions of `pip` may have issues with `pytorch-lightning`'s metadata format. If you encounter this issue, downgrade the version of `pip` that's embedded in the `visnet` environment, by running `pip install pip==24.0` from the activated environment (i.e. after `conda activate visnet`).
+- Note: newer versions of `pip` won't parse the metadata from `pytorch-lightning`'s distribution. If you encounter this issue, downgrade `pip` for this environment, by running:
+
+  ```shell
+  pip install pip==24.0
+  ```
+
+  from the activated environment (i.e. after `conda activate visnet`), then run the `pip install` commands again.
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ pip install pytorch-lightning==1.8.0
 pip install ase ase[test] ogb
 ```
 
+Note: newer versions of `pip` may have issues with `pytorch-lightning`'s metadata format. If you encounter this issue, downgrade the version of `pip` that's embedded in the `visnet` environment, by running `pip install pip==24.0` from the activated environment (i.e. after `conda activate visnet`).
+
 ## Getting started
 
 To train ViSNet on MD17, just run:


### PR DESCRIPTION
If the conda environment comes with `pip==24.3.1`, this version of `pip` won't allow installing `pytorch-lightning==1.8.0`:

```
Requested pytorch-lightning==1.8.0 from https://files.pythonhosted.org/packages/5c/6d/4719a089c57d55800ab820b4f157a354cc6f5db0d10356d53038150fd7b3/pytorch_lightning-1.8.0-py3-none-any.whl has invalid metadata: .* suffix can only be used with `==` or `!=` operators
    torch (>=1.9.*)
```

This PR documents a workaround in the README, that worked in my case, i.e. downgrading `pip`.

I haven't tried bisecting `pip` versions, so 24.0 may not be the most recent one that does the trick.